### PR TITLE
Address borrow mut error

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -129,7 +129,7 @@ pub fn ttl_cache(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #function_body
             }
             #static_var.with(|var| {
-                let cache = var.borrow_mut();
+                let cache = var.borrow();
                 if let Some(cached_result) = cache.get(#key) {
                     return cached_result;
                 } else {


### PR DESCRIPTION
Address a `BorrowMutError` from `fibonacci` example

closes #3